### PR TITLE
Babysteps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
-node_modules
-etc/bedclear
-etc/uuid
-tmp
+/node_modules
+/etc/bedclear
+/etc/uuid
+/tmp
+/uploads
+/node
+/package-lock.json
+/node-v*

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -131,12 +131,14 @@
                             <button onclick="origin_set()">Set Origin</button>
                             <button id="clear-origin" onclick="origin_clear()">Clear Origin</button>
                             <button onclick="origin_go()">Goto Origin</button>
+                            <button onclick="baby_z_down()">Babystep Down</button>
                         </div>
                         <div class="col">
                             <button onclick="send_safe('M17')">Enable motors</button>
                             <button onclick="send_safe('M18')">Disable motors</button>
                             <button id="up-z-probe" onclick="update_probe_z()">Update Probe Z</button>
                             <!--<button id="go-center" onclick="center_go()">Goto Center</button>-->
+                            <button onclick="baby_z_up()">Babystep Up</button>
                         </div>
                         <div class="col" id="abl">
                             <button onclick="probe_bed()">Auto Bed Level</button>

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -142,8 +142,8 @@
                         </div>
                         <div class="col" id="abl">
                             <button onclick="probe_bed()">Auto Bed Level</button>
-                            <button onclick="send_safe('M420 S1;M420')">Enable</button>
-                            <button onclick="send_safe('M420 S0;M420')">Disable</button>
+                            <button onclick="send_safe('M420 S1;M420')">UBL Enable</button>
+                            <button onclick="send_safe('M420 S0;M420')">UBL Disable</button>
                         </div>
                         <div class="grow"></div>
                     </div>

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -205,6 +205,14 @@ function origin_go() {
     }
 }
 
+function baby_z_down() {
+    send(`M290 Z-0.025; M503; *status`);
+}
+
+function baby_z_up() {
+    send(`M290 Z0.025; M503; *status`);
+}
+
 function origin_set() {
     if (alert_on_run()) return;
     if (mode === 'fdm' && last_set && last_set.pos) {


### PR DESCRIPTION
This is pretty easy to edit. I'm not sure I understand all of the intent of different things, so please be critical.

The babystepping code M290 does work for me. "Up" raises the Z up, giving more room for the filament. "Down" smooshes it down. While you are printing, you can tap these buttons to move the Z by 0.025mm. It also updates M851 Z.

We really need some feedback to tell us how far it has moved. Especially since there is a delay between pressing the button, and getting any change. I didn't see a good way to just update that in the status/config menu, but I want to be able to see what it's at. So I added `M503; *status`. Unfortunately, I think that's a lot of extra back and forth with Marlin, and it totally screws up the console log. I'd love it if you had a better way to get the offset returned from M290 into the M851 spot on the config page (or even show it on the control tab) to provide feedback on how far we've moved.

I also did the absolutely easiest thing and just hard coded it to 0.025mm up/down. It doesn't make sense to use the same increments as the movements, but maybe there is an intuitive way to allow it to be adjustable. Otherwise, 0.025mm is about as close as I can hope to get while printing on the fly anyway. Maybe a third button, where we have a single increment button, and the text changes to show which increment we are using, and it would toggle between 0.0125/0.025/0.05?

The other obvious problem I see with this is that not all printers have babystepping enabled. IDK if it will just silently fail, or if there's a way we can determine if it didn't work, and then tell the user?

I also added some stuff to the .gitignore, and I added the term UBL to the front Enable/Disable buttons. Feel free to keep or reject those too.